### PR TITLE
Remove References To Upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV GO111MODULE on
 
 RUN  \
      apk add --no-cache git && \
-     git clone https://github.com/minio/minio && cd minio && \
+     git clone https://github.com/RTradeLtd/s3x && cd minio && \
      go install -v -ldflags "$(go run buildscripts/gen-ldflags.go)"
 
 FROM alpine:3.10

--- a/Dockerfile.arm.release
+++ b/Dockerfile.arm.release
@@ -8,7 +8,7 @@ ENV GO111MODULE on
 
 RUN  \
      apk add --no-cache git 'curl>7.61.0' && \
-     git clone https://github.com/minio/minio && \
+     git clone https://github.com/RTradeLtd/s3x && \
      curl -L https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz | tar zxvf - -C . && mv qemu-3.0.0+resin-arm/qemu-arm-static . 
 
 FROM arm32v7/alpine:3.10

--- a/Dockerfile.arm64.release
+++ b/Dockerfile.arm64.release
@@ -8,7 +8,7 @@ ENV GO111MODULE on
 
 RUN  \
      apk add --no-cache git 'curl>7.61.0' && \
-     git clone https://github.com/minio/minio && \
+     git clone https://github.com/RTradeLtd/s3x && \
      curl -L https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz | tar zxvf - -C . && mv qemu-3.0.0+resin-arm/qemu-arm-static . 
 
 FROM arm64v8/alpine:3.10

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -6,7 +6,7 @@ ENV GO111MODULE on
 
 RUN  \
      apk add --no-cache git && \
-     git clone https://github.com/minio/minio
+     git clone https://github.com/RTradeLtd/s3x
 
 FROM alpine:3.10
 

--- a/Dockerfile.simpleci
+++ b/Dockerfile.simpleci
@@ -3,8 +3,8 @@
 #-------------------------------------------------------------
 FROM golang:1.13
 
-COPY . /go/src/github.com/minio/minio
-WORKDIR /go/src/github.com/minio/minio
+COPY . /go/src/github.com/RTradeLtd/s3x
+WORKDIR /go/src/github.com/RTradeLtd/s3x
 
 RUN apt-get update && apt-get install -y jq
 ENV GO111MODULE=on

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
 
 VERSION ?= $(shell git describe --tags)
-TAG ?= "minio/minio:$(VERSION)"
+TAG ?= "RTradeLtd/s3x:$(VERSION)"
 
 BUILD_LDFLAGS := '$(LDFLAGS)'
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
 
 VERSION ?= $(shell git describe --tags)
-TAG ?= "RTradeLtd/s3x:$(VERSION)"
+TAG ?= "rtradetech/s3x:$(VERSION)"
 
 BUILD_LDFLAGS := '$(LDFLAGS)'
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Whenever there is a security update you just need to upgrade to the latest versi
 
 ## Reporting a Vulnerability
 
-All security bugs in [minio/minio](https://github,com/minio/minio) (or other minio/* repositories)
+All security bugs in [RTradeLtd/s3x](https://github,com/RTradeLtd/s3x) (or other minio/* repositories)
 should be reported by email to security@min.io. Your email will be acknowledged within 48 hours,
 and you'll receive a more detailed response to your email within 72 hours indicating the next steps
 in handling your report.

--- a/browser/package.json
+++ b/browser/package.json
@@ -19,14 +19,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/minio/minio"
+    "url": "https://github.com/RTradeLtd/s3x"
   },
   "author": "MinIO Inc",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/RTradeLtd/s3x/issues"
   },
-  "homepage": "https://github.com/minio/minio",
+  "homepage": "https://github.com/RTradeLtd/s3x",
   "devDependencies": {
     "async": "^1.5.2",
     "babel-cli": "^6.26.0",

--- a/kubernetes_local.yml
+++ b/kubernetes_local.yml
@@ -34,7 +34,7 @@ spec:
             claimName: workdir
       containers:
         - name: s3x
-          image: rtradetech/s3x-test:latest
+          image: rtradetech/s3x:latest
           args: ["gateway", "s3x", "--temporalx.endpoint", "localhost:9090", "--temporalx.insecure"]
           env:
             - name: MINIO_ACCESS_KEY

--- a/kubernetes_remote.yml
+++ b/kubernetes_remote.yml
@@ -34,7 +34,7 @@ spec:
             claimName: workdir
       containers:
         - name: s3x
-          image: rtradetech/s3x-test:latest
+          image: rtradetech/s3x:latest
           args: ["gateway", "s3x", "--temporalx.insecure"]
           env:
             - name: MINIO_ACCESS_KEY

--- a/minio.spec
+++ b/minio.spec
@@ -1,6 +1,6 @@
 %define         tag     RELEASE.2017-04-25T01-27-49Z
 %define         subver  %(echo %{tag} | sed -e 's/[^0-9]//g')
-# git fetch https://github.com/minio/minio.git refs/tags/RELEASE.2017-02-16T01-47-30Z
+# git fetch https://github.com/RTradeLtd/s3x.git refs/tags/RELEASE.2017-02-16T01-47-30Z
 # git rev-list -n 1 FETCH_HEAD
 %define         commitid        83abb310b4ce3a0dfc6d7faf78e33cb6f9132cfe
 Summary:        Cloud Storage Server.
@@ -21,7 +21,7 @@ BuildRoot:      %{tmpdir}/%{name}-%{version}-root-%(id -u -n)
 ## Go related tags.
 %define         gobuild(o:) go build -ldflags "${LDFLAGS:-}" %{?**};
 %define         gopath          %{_libdir}/golang
-%define         import_path     github.com/minio/minio
+%define         import_path     github.com/RTradeLtd/s3x
 
 %description
 MinIO is an object storage server released under Apache License v2.0.


### PR DESCRIPTION
## Description

We had some dangling references to upstream in certain places, such as `package.json`, various dockerfiles, etc.. 

## Motivation and Context

This PR replaces `minio/minio` with `RTradeLtd/s3x` where appropriate, i've also updated the readme detailing the new crdt ledger store

## How to test this PR?

Nothing to test

## Types of changes
N/A

## Checklist:
N/A
