### PR TITLE
database passthrough

### DIFF
--- a/gateway/s3x/Makefile
+++ b/gateway/s3x/Makefile
@@ -2,10 +2,12 @@ gen:
 	# check out dependcies
 	# git clone https://github.com/gogo/protobuf.git ${GOPATH}/src/github.com/gogo/protobuf/
 	# git clone https://github.com/grpc-ecosystem/grpc-gateway.git ${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/
-	# go get -u github.com/gogo/protobuf/protoc-gen-gogofaster 
-	# go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
-	# go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
-	# go get -u github.com/golang/protobuf/protoc-gen-go
+	go get github.com/gogo/protobuf/protoc-gen-gogofaster 
+	go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+	go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
+	go get github.com/golang/protobuf/protoc-gen-go
+	go mod tidy
+
 	# generate golang bindings (dag)
 	protoc \
 		-I=. \

--- a/gateway/s3x/gateway-s3x-bucket_test.go
+++ b/gateway/s3x/gateway-s3x-bucket_test.go
@@ -13,14 +13,14 @@ const (
 )
 
 func TestS3X_Bucket_Badger(t *testing.T) {
-	testS3XBucket(t, DSTypeBadger)
+	testS3XBucket(t, DSTypeBadger, false)
 }
 func TestS3X_Bucket_Crdt(t *testing.T) {
-	testS3XBucket(t, DSTypeCrdt)
+	testS3XBucket(t, DSTypeCrdt, false)
 }
-func testS3XBucket(t *testing.T, dsType DSType) {
+func testS3XBucket(t *testing.T, dsType DSType, passthrough bool) {
 	ctx := context.Background()
-	gateway := newTestGateway(t, dsType)
+	gateway := newTestGateway(t, dsType, passthrough)
 	defer func() {
 		if err := gateway.Shutdown(ctx); err != nil {
 			t.Fatal(err)

--- a/gateway/s3x/gateway-s3x-bucket_test.go
+++ b/gateway/s3x/gateway-s3x-bucket_test.go
@@ -15,8 +15,14 @@ const (
 func TestS3X_Bucket_Badger(t *testing.T) {
 	testS3XBucket(t, DSTypeBadger, false)
 }
+func TestS3X_Bucket_Badger_Passthrough(t *testing.T) {
+	testS3XBucket(t, DSTypeBadger, true)
+}
 func TestS3X_Bucket_Crdt(t *testing.T) {
 	testS3XBucket(t, DSTypeCrdt, false)
+}
+func TestS3X_Bucket_Crdt_Passthrough(t *testing.T) {
+	testS3XBucket(t, DSTypeCrdt, true)
 }
 func testS3XBucket(t *testing.T, dsType DSType, passthrough bool) {
 	ctx := context.Background()

--- a/gateway/s3x/gateway-s3x-ledger-bucket.go
+++ b/gateway/s3x/gateway-s3x-ledger-bucket.go
@@ -56,32 +56,43 @@ func (ls *ledgerStore) GetBucketHash(bucket string) (string, error) {
 // if err is returned, then the datastore can not be read
 // if nil, nil is return, then bucket does not exit
 func (ls *ledgerStore) getBucketNilable(bucket string) (*LedgerBucketEntry, error) {
-	ls.mapLocker.Lock()
-	b, ok := ls.l.Buckets[bucket]
-	ls.mapLocker.Unlock()
-	if !ok {
+	load := func() (*LedgerBucketEntry, error) {
 		bHash, err := ls.ds.Get(dsBucketKey.ChildString(bucket))
 		if err != nil {
 			if err == datastore.ErrNotFound {
-				ls.mapLocker.Lock()
-				ls.l.Buckets[bucket] = nil
-				ls.mapLocker.Unlock()
 				return nil, nil
 			}
 			return nil, err
 		}
-		//Update bucket only if it's not loaded
-		ls.mapLocker.Lock()
-		b, ok = ls.l.Buckets[bucket]
-		if !ok {
-			b = &LedgerBucketEntry{
-				IpfsHash: string(bHash),
-			}
-			ls.l.Buckets[bucket] = b
-		}
-		ls.mapLocker.Unlock()
+		return &LedgerBucketEntry{
+			IpfsHash: string(bHash),
+		}, nil
 	}
-	return b, nil
+
+	if ls.l == nil {
+		return load()
+	}
+
+	ls.mapLocker.Lock()
+	b, ok := ls.l.Buckets[bucket]
+	ls.mapLocker.Unlock()
+	if ok {
+		return b, nil
+	}
+	b, err := load()
+	if err != nil {
+		return nil, err
+	}
+	//Update bucket only if it's not loaded since we released lock during load
+	ls.mapLocker.Lock()
+	if b2, exist := ls.l.Buckets[bucket]; !exist {
+		ls.l.Buckets[bucket] = b
+		ls.mapLocker.Unlock()
+		return b, nil
+	} else {
+		ls.mapLocker.Unlock()
+		return b2, nil
+	}
 }
 
 // getBucketRequired returns a lazy loading LedgerBucketEntry

--- a/gateway/s3x/gateway-s3x-ledger-bucket.go
+++ b/gateway/s3x/gateway-s3x-ledger-bucket.go
@@ -163,18 +163,20 @@ func (ls *ledgerStore) saveBucket(ctx context.Context, bucket string, b *Bucket)
 	if err != nil {
 		return nil, err
 	}
+
+	//save hash to ledger
 	if err := ls.ds.Put(dsBucketKey.ChildString(bucket), []byte(bHash)); err != nil {
 		return nil, err
 	}
-
-	//save hash to ledger
 	lb := &LedgerBucketEntry{
 		Bucket:   b,
 		IpfsHash: bHash,
 	}
-	ls.mapLocker.Lock()
-	ls.l.Buckets[bucket] = lb
-	ls.mapLocker.Unlock()
+	if ls.l != nil {
+		ls.mapLocker.Lock()
+		ls.l.Buckets[bucket] = lb
+		ls.mapLocker.Unlock()
+	}
 	return lb, nil
 }
 
@@ -208,9 +210,11 @@ func (ls *ledgerStore) DeleteBucket(bucket string) error {
 	if err != nil {
 		return err
 	}
-	ls.mapLocker.Lock()
-	delete(ls.l.Buckets, bucket)
-	ls.mapLocker.Unlock()
+	if ls.l != nil {
+		ls.mapLocker.Lock()
+		delete(ls.l.Buckets, bucket)
+		ls.mapLocker.Unlock()
+	}
 	return ls.ds.Delete(dsBucketKey.ChildString(bucket))
 	//todo: remove from ipfs
 }

--- a/gateway/s3x/gateway-s3x-ledger-bucket.go
+++ b/gateway/s3x/gateway-s3x-ledger-bucket.go
@@ -85,14 +85,14 @@ func (ls *ledgerStore) getBucketNilable(bucket string) (*LedgerBucketEntry, erro
 	}
 	//Update bucket only if it's not loaded since we released lock during load
 	ls.mapLocker.Lock()
-	if b2, exist := ls.l.Buckets[bucket]; !exist {
-		ls.l.Buckets[bucket] = b
-		ls.mapLocker.Unlock()
-		return b, nil
-	} else {
+	b2, exist := ls.l.Buckets[bucket]
+	if exist {
 		ls.mapLocker.Unlock()
 		return b2, nil
 	}
+	ls.l.Buckets[bucket] = b
+	ls.mapLocker.Unlock()
+	return b, nil
 }
 
 // getBucketRequired returns a lazy loading LedgerBucketEntry

--- a/gateway/s3x/gateway-s3x-ledger-store.go
+++ b/gateway/s3x/gateway-s3x-ledger-store.go
@@ -42,14 +42,16 @@ type ledgerStore struct {
 	cleanup []func() error //a list of functions to call before we close the backing database.
 }
 
-func newLedgerStore(ds datastore.Batching, dag pb.NodeAPIClient) (*ledgerStore, error) {
+func newLedgerStore(ds datastore.Batching, dag pb.NodeAPIClient, passthrough bool) (*ledgerStore, error) {
 	ls := &ledgerStore{
 		ds:  namespace.Wrap(ds, dsPrefix),
 		dag: dag,
-		l: &Ledger{
+	}
+	if !passthrough {
+		ls.l = &Ledger{
 			Buckets:          make(map[string]*LedgerBucketEntry),
 			MultipartUploads: make(map[string]*MultipartUpload),
-		},
+		}
 	}
 	return ls, nil
 }

--- a/gateway/s3x/gateway-s3x-ledger_test.go
+++ b/gateway/s3x/gateway-s3x-ledger_test.go
@@ -10,21 +10,21 @@ import (
 )
 
 func TestS3X_LedgerStore_Badger(t *testing.T) {
-	testS3XLedgerStore(t, DSTypeBadger)
+	testS3XLedgerStore(t, DSTypeBadger, false)
 }
 func TestS3X_LedgerStore_Crdt(t *testing.T) {
-	testS3XLedgerStore(t, DSTypeCrdt)
+	testS3XLedgerStore(t, DSTypeCrdt, false)
 }
-func testS3XLedgerStore(t *testing.T, dsType DSType) {
+func testS3XLedgerStore(t *testing.T, dsType DSType, passthrough bool) {
 	ctx := context.Background()
-	gateway := newTestGateway(t, dsType)
+	gateway := newTestGateway(t, dsType, passthrough)
 	defer func() {
 		if err := gateway.Shutdown(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	ledger, err := newLedgerStore(dssync.MutexWrap(datastore.NewMapDatastore()), gateway.dagClient)
+	ledger, err := newLedgerStore(dssync.MutexWrap(datastore.NewMapDatastore()), gateway.dagClient, passthrough)
 
 	if err != nil {
 		t.Fatal(err)

--- a/gateway/s3x/gateway-s3x-ledger_test.go
+++ b/gateway/s3x/gateway-s3x-ledger_test.go
@@ -12,8 +12,14 @@ import (
 func TestS3X_LedgerStore_Badger(t *testing.T) {
 	testS3XLedgerStore(t, DSTypeBadger, false)
 }
+func TestS3X_LedgerStore_Badger_Passthrough(t *testing.T) {
+	testS3XLedgerStore(t, DSTypeBadger, true)
+}
 func TestS3X_LedgerStore_Crdt(t *testing.T) {
 	testS3XLedgerStore(t, DSTypeCrdt, false)
+}
+func TestS3X_LedgerStore_Crdt_Passthrough(t *testing.T) {
+	testS3XLedgerStore(t, DSTypeCrdt, true)
 }
 func testS3XLedgerStore(t *testing.T, dsType DSType, passthrough bool) {
 	ctx := context.Background()

--- a/gateway/s3x/gateway-s3x-multipart_test.go
+++ b/gateway/s3x/gateway-s3x-multipart_test.go
@@ -11,8 +11,14 @@ import (
 func TestS3X_Multipart_Badger(t *testing.T) {
 	testS3XMultipart(t, DSTypeBadger, false)
 }
+func TestS3X_Multipart_Badger_Passthrough(t *testing.T) {
+	testS3XMultipart(t, DSTypeBadger, true)
+}
 func TestS3X_Multipart_Crdt(t *testing.T) {
 	testS3XMultipart(t, DSTypeCrdt, false)
+}
+func TestS3X_Multipart_Crdt_Passthrough(t *testing.T) {
+	testS3XMultipart(t, DSTypeCrdt, true)
 }
 func testS3XMultipart(t *testing.T, dsType DSType, passthrough bool) {
 	bucket := "my multipart bucket"

--- a/gateway/s3x/gateway-s3x-multipart_test.go
+++ b/gateway/s3x/gateway-s3x-multipart_test.go
@@ -9,17 +9,17 @@ import (
 )
 
 func TestS3X_Multipart_Badger(t *testing.T) {
-	testS3XMultipart(t, DSTypeBadger)
+	testS3XMultipart(t, DSTypeBadger, false)
 }
 func TestS3X_Multipart_Crdt(t *testing.T) {
-	testS3XMultipart(t, DSTypeCrdt)
+	testS3XMultipart(t, DSTypeCrdt, false)
 }
-func testS3XMultipart(t *testing.T, dsType DSType) {
+func testS3XMultipart(t *testing.T, dsType DSType, passthrough bool) {
 	bucket := "my multipart bucket"
 	object := "my multipart object"
 	objectETag := "bafybeibzfoslocl3zs4fngsqminlpikibos7u664circ6mw7kjwkwa6y54"
 	ctx := context.Background()
-	gateway := newTestGateway(t, dsType)
+	gateway := newTestGateway(t, dsType, passthrough)
 	defer func() {
 		if err := gateway.Shutdown(ctx); err != nil {
 			t.Fatal(err)

--- a/gateway/s3x/gateway-s3x-object_test.go
+++ b/gateway/s3x/gateway-s3x-object_test.go
@@ -72,8 +72,14 @@ func testGetObject(t *testing.T, g *testGateway) {
 func TestS3XG_Object_Badger(t *testing.T) {
 	testS3XGObject(t, DSTypeBadger, false)
 }
+func TestS3XG_Object_Badger_Passthrough(t *testing.T) {
+	testS3XGObject(t, DSTypeBadger, true)
+}
 func TestS3XG_Object_Crdt(t *testing.T) {
 	testS3XGObject(t, DSTypeCrdt, false)
+}
+func TestS3XG_Object_Crdt_Passthrough(t *testing.T) {
+	testS3XGObject(t, DSTypeCrdt, true)
 }
 func testS3XGObject(t *testing.T, dsType DSType, passthrough bool) {
 	ctx := context.Background()

--- a/gateway/s3x/gateway-s3x-object_test.go
+++ b/gateway/s3x/gateway-s3x-object_test.go
@@ -70,14 +70,14 @@ func testGetObject(t *testing.T, g *testGateway) {
 }
 
 func TestS3XG_Object_Badger(t *testing.T) {
-	testS3XGObject(t, DSTypeBadger)
+	testS3XGObject(t, DSTypeBadger, false)
 }
 func TestS3XG_Object_Crdt(t *testing.T) {
-	testS3XGObject(t, DSTypeCrdt)
+	testS3XGObject(t, DSTypeCrdt, false)
 }
-func testS3XGObject(t *testing.T, dsType DSType) {
+func testS3XGObject(t *testing.T, dsType DSType, passthrough bool) {
 	ctx := context.Background()
-	gateway := newTestGateway(t, dsType)
+	gateway := newTestGateway(t, dsType, passthrough)
 	defer func() {
 		if err := gateway.Shutdown(ctx); err != nil {
 			t.Fatal(err)

--- a/gateway/s3x/gateway-s3x.go
+++ b/gateway/s3x/gateway-s3x.go
@@ -99,6 +99,10 @@ func init() {
 				Usage: "the type backend to store ledger data in, supported values are [badger, crdt]",
 				Value: "badger",
 			},
+			cli.BoolFlag{
+				Name:  "ds.passthrough",
+				Usage: "turns off in-memory cache of some datastratures, lowers memory usage and allows network sync of the datastore to work, at a cost of performance",
+			},
 			cli.StringFlag{
 				Name:  "ds.topic",
 				Usage: "the topic used for crdt pubsub",

--- a/gateway/s3x/gateway-s3x.go
+++ b/gateway/s3x/gateway-s3x.go
@@ -37,13 +37,14 @@ const (
 
 // TEMX implements a MinIO gateway on top of TemporalX
 type TEMX struct {
-	HTTPAddr  string
-	GRPCAddr  string
-	DSType    DSType
-	DSPath    string
-	CrdtTopic string
-	XAddr     string
-	Insecure  bool // whether or not we have an insecure connection to TemporalX
+	HTTPAddr      string // HTTP address and port to serve from
+	GRPCAddr      string // GRPC address and port to serve from
+	DSType        DSType // the type of database to use
+	DSPath        string // the location of local data for the database
+	DSPassthrough bool   // turns off in-memory cache of some datastratures, lowers memory usage and allows network sync of the datastore to work, at a cost of performance.
+	CrdtTopic     string // if the database type is crdt, then this is used as the pubsub topic
+	XAddr         string // server and port of the XAPI address
+	Insecure      bool   // skip certificate verification when connecting to TemporalX
 }
 
 // infoAPIServer provides access to the InfoAPI
@@ -148,7 +149,7 @@ func (g *TEMX) newBadgerLedgerStore(dag pb.NodeAPIClient) (*ledgerStore, error) 
 	if err != nil {
 		return nil, err
 	}
-	return newLedgerStore(ds, dag)
+	return newLedgerStore(ds, dag, g.DSPassthrough)
 }
 
 // newCrdtLedgerStore returns an instance of ledgerStore that uses crdt and backed by badgerv2
@@ -177,7 +178,7 @@ func (g *TEMX) newCrdtLedgerStore(ctx context.Context, dag pb.NodeAPIClient, pub
 	if err != nil {
 		return nil, err
 	}
-	ls, err := newLedgerStore(crdtds, dag)
+	ls, err := newLedgerStore(crdtds, dag, g.DSPassthrough)
 	if err != nil {
 		return nil, err
 	}

--- a/gateway/s3x/gateway-s3x_test.go
+++ b/gateway/s3x/gateway-s3x_test.go
@@ -9,8 +9,14 @@ import (
 func TestS3X_xObjects_GetHash_Badger(t *testing.T) {
 	testS3XxObjectsGetHash(t, DSTypeBadger, false)
 }
+func TestS3X_xObjects_GetHash_Badger_Passthrough(t *testing.T) {
+	testS3XxObjectsGetHash(t, DSTypeBadger, true)
+}
 func TestS3X_xObjects_GetHash_Crdt(t *testing.T) {
 	testS3XxObjectsGetHash(t, DSTypeCrdt, false)
+}
+func TestS3X_xObjects_GetHash_Crdt_Passthrough(t *testing.T) {
+	testS3XxObjectsGetHash(t, DSTypeCrdt, true)
 }
 func testS3XxObjectsGetHash(t *testing.T, dsType DSType, passthrough bool) {
 	tests := []struct {

--- a/gateway/s3x/gateway-s3x_test.go
+++ b/gateway/s3x/gateway-s3x_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestS3X_xObjects_GetHash_Badger(t *testing.T) {
-	testS3XxObjectsGetHash(t, DSTypeBadger)
+	testS3XxObjectsGetHash(t, DSTypeBadger, false)
 }
 func TestS3X_xObjects_GetHash_Crdt(t *testing.T) {
-	testS3XxObjectsGetHash(t, DSTypeCrdt)
+	testS3XxObjectsGetHash(t, DSTypeCrdt, false)
 }
-func testS3XxObjectsGetHash(t *testing.T, dsType DSType) {
+func testS3XxObjectsGetHash(t *testing.T, dsType DSType, passthrough bool) {
 	tests := []struct {
 		name    string
 		req     *InfoRequest
@@ -26,7 +26,7 @@ func testS3XxObjectsGetHash(t *testing.T, dsType DSType) {
 	}
 
 	ctx := context.Background()
-	gateway := newTestGateway(t, dsType)
+	gateway := newTestGateway(t, dsType, passthrough)
 	defer func() {
 		if err := gateway.Shutdown(ctx); err != nil {
 			t.Fatal(err)

--- a/gateway/s3x/s3.pb.go
+++ b/gateway/s3x/s3.pb.go
@@ -6,11 +6,6 @@ package s3x
 import (
 	context "context"
 	fmt "fmt"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-	time "time"
-
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
@@ -18,6 +13,10 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+	time "time"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -327,7 +326,7 @@ func (m *BucketInfo) GetLocation() string {
 	return ""
 }
 
-// Bucket is a data repositroy for S3 objects
+// Bucket is a data repository for S3 objects
 type Bucket struct {
 	// data associated with the object
 	Data []byte `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
@@ -395,7 +394,7 @@ func (m *Bucket) GetObjects() map[string]string {
 // the data field contains the actual data
 // referred to by this object, while the objectInfo
 // field is used to contain the information associated
-// wth the object
+// with the object
 type Object struct {
 	DataHash   string     `protobuf:"bytes,1,opt,name=dataHash,proto3" json:"dataHash,omitempty"`
 	ObjectInfo ObjectInfo `protobuf:"bytes,2,opt,name=objectInfo,proto3" json:"objectInfo"`
@@ -624,7 +623,7 @@ func (m *ObjectInfo) GetContentLanguage() string {
 // ObjectPartInfo contains information an individual object client.
 // For Etag, use dataHash
 type ObjectPartInfo struct {
-	// convertable to "int" type in minio.PartInfo
+	// convertible to "int" type in minio.PartInfo
 	Number int64 `protobuf:"varint,1,opt,name=number,proto3" json:"number,omitempty"`
 	// name of object in bucket
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`

--- a/gateway/s3x/s3.pb.gw.go
+++ b/gateway/s3x/s3.pb.gw.go
@@ -55,7 +55,10 @@ func local_request_InfoAPI_GetHash_0(ctx context.Context, marshaler runtime.Mars
 	var protoReq InfoRequest
 	var metadata runtime.ServerMetadata
 
-	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_InfoAPI_GetHash_0); err != nil {
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_InfoAPI_GetHash_0); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 

--- a/gateway/s3x/s3.proto
+++ b/gateway/s3x/s3.proto
@@ -50,7 +50,7 @@ message BucketInfo {
 }
 
 
-// Bucket is a data repositroy for S3 objects
+// Bucket is a data repository for S3 objects
 message Bucket {
     // data associated with the object
     bytes data = 1;
@@ -64,7 +64,7 @@ message Bucket {
 // the data field contains the actual data 
 // referred to by this object, while the objectInfo
 // field is used to contain the information associated
-// wth the object
+// with the object
 message Object {
     string dataHash = 1;
     ObjectInfo objectInfo = 2 [(gogoproto.nullable) = false];
@@ -95,7 +95,7 @@ message ObjectInfo {
 // ObjectPartInfo contains information an individual object client.
 // For Etag, use dataHash
 message ObjectPartInfo {
-    // convertable to "int" type in minio.PartInfo
+    // convertible to "int" type in minio.PartInfo
     int64 number = 1;
     // name of object in bucket
     string name = 2;

--- a/gateway/s3x/s3x_test.go
+++ b/gateway/s3x/s3x_test.go
@@ -53,7 +53,7 @@ var (
 
 // newTestGateway returns a testGateway that implements minio.ObjectLayer.
 // testGateway also removes all data save on disk when shutdown
-func newTestGateway(t *testing.T, dsType DSType) *testGateway {
+func newTestGateway(t *testing.T, dsType DSType, passthrough bool) *testGateway {
 	pathOnce.Do(func() {
 		testPath, testPathErr = ioutil.TempDir("", "s3x-test")
 	})
@@ -70,13 +70,14 @@ func newTestGateway(t *testing.T, dsType DSType) *testGateway {
 	}
 	os.Setenv("S3X_DS_PATH", testPath)
 	temx := &TEMX{
-		HTTPAddr:  "localhost:8889",
-		GRPCAddr:  "localhost:8888",
-		DSType:    dsType,
-		DSPath:    testPath,
-		CrdtTopic: testPath + time.Now().String(), //make sure the topic is unique
-		XAddr:     xaddr,
-		Insecure:  true,
+		HTTPAddr:      "localhost:8889",
+		GRPCAddr:      "localhost:8888",
+		DSType:        dsType,
+		DSPath:        testPath,
+		DSPassthrough: passthrough,
+		CrdtTopic:     testPath + time.Now().String(), //make sure the topic is unique
+		XAddr:         xaddr,
+		Insecure:      true,
 	}
 	g, err := temx.NewGatewayLayer(auth.Credentials{})
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
## Description
Added a option to allow enabling database passthrough. When enabled, the in memory ledger is always nil and unused.

## Motivation and Context
By allowing the underling database to take full control of the ledger, this allows online syncization of the database to be reflected without restarting the server. This opens up more opportunities for us to take advantage of syncization features of datastores, such as multimaster crdt.

Performance wise, turning this option on will decrease memory usage, but increase cpu usage by increasing deserlization.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

